### PR TITLE
Store service worker events in influx and Postgres

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,7 @@ serde_json = "1.0.108"
 influxdb = "0.7.1"
 chrono = "0.4.31"
 dotenv = "0.15.0"
+diesel = { version = "2.1.4", features = ["postgres", "serde_json", "r2d2", "uuid"] }
+r2d2 = "0.8.10"
+uuid = { version = "1.6.1", features = ["serde", "v4"] }
+actix-cors = "0.6.5"

--- a/Makefile
+++ b/Makefile
@@ -6,3 +6,4 @@ run:
 
 run-dependencies:
 	docker run -d -p 8086:8086 -v influxdb:/var/lib/influxdb influxdb
+	docker run -d -p 5432:5432 -e POSTGRES_PASSWORD=postgres -v postgres:/var/lib/postgresql/data postgres

--- a/diesel.toml
+++ b/diesel.toml
@@ -1,0 +1,9 @@
+# For documentation on how to configure this file,
+# see https://diesel.rs/guides/configuring-diesel-cli
+
+[print_schema]
+file = "src/schema.rs"
+custom_type_derives = ["diesel::query_builder::QueryId"]
+
+[migrations_directory]
+dir = "migrations"

--- a/migrations/00000000000000_diesel_initial_setup/down.sql
+++ b/migrations/00000000000000_diesel_initial_setup/down.sql
@@ -1,0 +1,6 @@
+-- This file was automatically created by Diesel to setup helper functions
+-- and other internal bookkeeping. This file is safe to edit, any future
+-- changes will be added to existing projects as new migrations.
+
+DROP FUNCTION IF EXISTS diesel_manage_updated_at(_tbl regclass);
+DROP FUNCTION IF EXISTS diesel_set_updated_at();

--- a/migrations/00000000000000_diesel_initial_setup/up.sql
+++ b/migrations/00000000000000_diesel_initial_setup/up.sql
@@ -1,0 +1,38 @@
+-- This file was automatically created by Diesel to setup helper functions
+-- and other internal bookkeeping. This file is safe to edit, any future
+-- changes will be added to existing projects as new migrations.
+
+
+
+
+-- Sets up a trigger for the given table to automatically set a column called
+-- `updated_at` whenever the row is modified (unless `updated_at` was included
+-- in the modified columns)
+--
+-- # Example
+--
+-- ```sql
+-- CREATE TABLE users (id SERIAL PRIMARY KEY, updated_at TIMESTAMP NOT NULL DEFAULT NOW());
+--
+-- SELECT diesel_manage_updated_at('users');
+-- ```
+CREATE OR REPLACE FUNCTION diesel_manage_updated_at(_tbl regclass) RETURNS VOID AS $$
+BEGIN
+    EXECUTE format('CREATE TRIGGER set_updated_at BEFORE UPDATE ON %s
+                    FOR EACH ROW EXECUTE PROCEDURE diesel_set_updated_at()', _tbl);
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION diesel_set_updated_at() RETURNS trigger AS $$
+BEGIN
+    IF (
+        NEW IS DISTINCT FROM OLD AND
+        NEW.updated_at IS NOT DISTINCT FROM OLD.updated_at
+    ) THEN
+        NEW.updated_at := current_timestamp;
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";

--- a/migrations/2024-01-03-064442_create_events_table/down.sql
+++ b/migrations/2024-01-03-064442_create_events_table/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS events;

--- a/migrations/2024-01-03-064442_create_events_table/up.sql
+++ b/migrations/2024-01-03-064442_create_events_table/up.sql
@@ -1,0 +1,8 @@
+CREATE TABLE events (
+    id uuid PRIMARY KEY,
+    browser_id VARCHAR(255),
+    client_id VARCHAR(255),
+    handled JSONB,
+    replaces_client_id VARCHAR(255),
+    resulting_client_id VARCHAR(255)
+);

--- a/migrations/2024-01-03-064556_create_requests_table/down.sql
+++ b/migrations/2024-01-03-064556_create_requests_table/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS requests;

--- a/migrations/2024-01-03-064556_create_requests_table/up.sql
+++ b/migrations/2024-01-03-064556_create_requests_table/up.sql
@@ -1,0 +1,18 @@
+CREATE TABLE requests (
+    id uuid PRIMARY KEY,
+    event_id uuid REFERENCES events(id),
+    body TEXT,
+    body_used BOOLEAN,
+    cache VARCHAR(255),
+    credentials VARCHAR(255),
+    destination VARCHAR(255),
+    headers JSONB,
+    integrity VARCHAR(255),
+    method VARCHAR(255),
+    mode VARCHAR(255),
+    redirect VARCHAR(255),
+    referrer VARCHAR(255),
+    referrer_policy VARCHAR(255),
+    url VARCHAR(255),
+    signal JSONB
+);

--- a/migrations/2024-01-03-064652_create_responses_table/down.sql
+++ b/migrations/2024-01-03-064652_create_responses_table/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS responses;

--- a/migrations/2024-01-03-064652_create_responses_table/up.sql
+++ b/migrations/2024-01-03-064652_create_responses_table/up.sql
@@ -1,0 +1,13 @@
+CREATE TABLE responses (
+    id uuid PRIMARY KEY,
+    event_id uuid REFERENCES events(id),
+    body TEXT,
+    body_used BOOLEAN,
+    headers JSONB,
+    ok BOOLEAN,
+    redirected BOOLEAN,
+    status INTEGER,
+    status_text VARCHAR(255),
+    response_type VARCHAR(255),
+    url VARCHAR(255)
+);

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,6 +6,7 @@ pub struct Config {
     pub influxdb_url: String,
     pub influxdb_db: String,
     pub influxdb_token: String,
+    pub database_url: String,
 }
 
 impl Config {
@@ -15,6 +16,7 @@ impl Config {
                 .unwrap_or_else(|_| "http://localhost:8086".to_string()),
             influxdb_db: env::var("INFLUXDB_DB").unwrap_or_else(|_| "encinitas".to_string()),
             influxdb_token: env::var("INFLUXDB_TOKEN").unwrap_or_else(|_| "".to_string()),
+            database_url: env::var("DATABASE_URL").unwrap_or_else(|_| "localhost".to_string()),
         })
     }
 }

--- a/src/domain/aggregates/event.rs
+++ b/src/domain/aggregates/event.rs
@@ -1,40 +1,42 @@
 pub struct EventData {
-    pub event_type: String,
-    pub request: String,
+    pub id: String,
     pub client_id: String,
-    pub preload_response: Option<String>,
+    pub handled: serde_json::Value,
+    pub replaces_client_id: Option<String>,
     pub resulting_client_id: String,
-    pub replaces_client_id: String,
 }
 
 pub struct RequestData {
-    pub url: String,
-    pub method: String,
     pub body: Option<String>,
+    pub body_used: bool,
+    pub cache: String,
+    pub credentials: String,
+    pub destination: String,
+    pub headers: serde_json::Value,
+    pub integrity: String,
+    pub method: String,
+    pub mode: String,
+    pub redirect: String,
     pub referrer: String,
     pub referrer_policy: String,
-    pub mode: String,
-    pub credentials: String,
-    pub cache: String,
-    pub redirect: String,
-    pub integrity: String,
-    pub keepalive: bool,
-    pub signal: Option<String>,
+    pub url: String,
+    pub signal: serde_json::Value,
 }
 
 pub struct ResponseData {
-    pub url: String,
-    pub response_type: String,
-    pub status: u16,
-    pub ok: bool,
-    pub status_text: String,
     pub body: Option<String>,
-    pub redirected: bool,
     pub body_used: bool,
+    pub headers: serde_json::Value,
+    pub ok: bool,
+    pub redirected: bool,
+    pub status: u16,
+    pub status_text: String,
+    pub response_type: String,
+    pub url: String,
 }
 
 pub struct Event {
     pub event: EventData,
-    pub request: RequestData,
-    pub response: ResponseData,
+    pub request: Option<RequestData>,
+    pub response: Option<ResponseData>,
 }

--- a/src/domain/services/events_creator.rs
+++ b/src/domain/services/events_creator.rs
@@ -2,17 +2,34 @@ use std::error::Error;
 
 use crate::domain::aggregates::event::Event;
 use crate::infrastructure::repositories::influx::InfluxRepository;
+use crate::infrastructure::repositories::sql::PostgresRepository;
 
 pub struct EventsCreator {
-    repository: InfluxRepository,
+    influx_repository: InfluxRepository,
+    postgres_repository: PostgresRepository,
 }
 
 impl EventsCreator {
-    pub fn new(repository: InfluxRepository) -> Self {
-        Self { repository }
+    pub fn new(
+        influx_repository: InfluxRepository,
+        postgres_repository: PostgresRepository,
+    ) -> Self {
+        Self {
+            influx_repository,
+            postgres_repository,
+        }
     }
 
     pub async fn create(&self, event: &Event) -> Result<(), Box<dyn Error>> {
-        return self.repository.create(event).await;
+        self.influx_repository.create(event).await;
+
+        self.postgres_repository.create_event(event)?;
+        if event.request.is_some() {
+            self.postgres_repository.create_request(event)?;
+        }
+        if event.response.is_some() {
+            self.postgres_repository.create_response(event)?;
+        }
+        Ok(())
     }
 }

--- a/src/infrastructure/repositories/influx.rs
+++ b/src/infrastructure/repositories/influx.rs
@@ -16,7 +16,42 @@ impl InfluxRepository {
         let timestamp = Timestamp::Milliseconds(Utc::now().timestamp_millis().try_into()?);
 
         let mut query = WriteQuery::new(timestamp, "event");
-        query = query.add_field("event_type", &event.event.event_type.as_str());
+        query = query
+            .add_field("id", event.event.id.clone())
+            .add_field("client_id", event.event.client_id.clone())
+            .add_field("replaces_client_id", event.event.replaces_client_id.clone())
+            .add_field(
+                "resulting_client_id",
+                event.event.resulting_client_id.clone(),
+            );
+
+        if let Some(request) = &event.request {
+            query = query
+                .add_field("request_body", request.body.clone().unwrap_or_default())
+                .add_field("request_body_used", request.body_used.clone())
+                .add_field("request_cache", request.cache.clone())
+                .add_field("request_credentials", request.credentials.clone())
+                .add_field("request_destination", request.destination.clone())
+                .add_field("request_integrity", request.integrity.clone())
+                .add_field("request_method", request.method.clone())
+                .add_field("request_mode", request.mode.clone())
+                .add_field("request_redirect", request.redirect.clone())
+                .add_field("request_referrer", request.referrer.clone())
+                .add_field("request_referrer_policy", request.referrer_policy.clone())
+                .add_field("request_url", request.url.clone())
+        }
+
+        if let Some(response) = &event.response {
+            query = query
+                .add_field("response_body", response.body.clone().unwrap_or_default())
+                .add_field("response_body_used", response.body_used)
+                .add_field("response_ok", response.ok)
+                .add_field("response_redirected", response.redirected)
+                .add_field("response_status", response.status)
+                .add_field("response_status_text", response.status_text.clone())
+                .add_field("response_response_type", response.response_type.clone())
+                .add_field("response_url", response.url.clone());
+        }
 
         let result = self.client.query(&query).await;
         match result {

--- a/src/infrastructure/repositories/mod.rs
+++ b/src/infrastructure/repositories/mod.rs
@@ -1,1 +1,3 @@
 pub mod influx;
+pub mod sql;
+pub mod sql_models;

--- a/src/infrastructure/repositories/sql.rs
+++ b/src/infrastructure/repositories/sql.rs
@@ -1,0 +1,55 @@
+use diesel::prelude::*;
+use diesel::r2d2::ConnectionManager;
+use r2d2::{Pool, PooledConnection};
+
+use crate::domain::aggregates::event::Event;
+use crate::infrastructure::repositories::sql_models::{events, requests, responses};
+
+use super::sql_models::db_event_from_aggregate;
+use super::sql_models::db_request_from_aggregate;
+use super::sql_models::db_response_from_aggregate;
+
+pub struct PostgresRepository {
+    pool: Pool<ConnectionManager<PgConnection>>,
+}
+
+impl PostgresRepository {
+    pub fn new(database_url: &str) -> Self {
+        let manager = ConnectionManager::<PgConnection>::new(database_url);
+        let pool = r2d2::Pool::builder()
+            .build(manager)
+            .expect("Failed to create pool.");
+        Self { pool }
+    }
+
+    // Example of a method using the pool
+    pub fn get_connection(
+        &self,
+    ) -> Result<PooledConnection<ConnectionManager<PgConnection>>, r2d2::Error> {
+        self.pool.get()
+    }
+
+    pub fn create_event(&self, event: &Event) -> QueryResult<usize> {
+        let db_event = db_event_from_aggregate(&event.event);
+        let mut conn = self.get_connection().expect("Failed to get connection");
+        diesel::insert_into(events::table)
+            .values(db_event)
+            .execute(&mut conn)
+    }
+
+    pub fn create_request(&self, event: &Event) -> QueryResult<usize> {
+        let db_request = db_request_from_aggregate(event.request.as_ref().unwrap());
+        let mut conn = self.get_connection().expect("Failed to get connection");
+        diesel::insert_into(requests::table)
+            .values(db_request)
+            .execute(&mut conn)
+    }
+
+    pub fn create_response(&self, event: &Event) -> QueryResult<usize> {
+        let mut conn = self.get_connection().expect("Failed to get connection");
+        let db_response = db_response_from_aggregate(event.response.as_ref().unwrap());
+        diesel::insert_into(responses::table)
+            .values(db_response)
+            .execute(&mut conn)
+    }
+}

--- a/src/infrastructure/repositories/sql_models.rs
+++ b/src/infrastructure/repositories/sql_models.rs
@@ -1,0 +1,150 @@
+use diesel::insertable::Insertable;
+use diesel::{allow_tables_to_appear_in_same_query, joinable, table};
+use uuid::Uuid;
+
+use crate::domain::aggregates::event::{EventData, RequestData, ResponseData};
+
+#[derive(Insertable)]
+#[table_name = "events"]
+pub struct DBEvent {
+    pub id: Uuid,
+    pub browser_id: String,
+    pub client_id: String,
+    pub handled: serde_json::Value,
+    pub replaces_client_id: Option<String>,
+    pub resulting_client_id: String,
+}
+
+pub fn db_event_from_aggregate(event: &EventData) -> DBEvent {
+    DBEvent {
+        id: Uuid::new_v4(),
+        browser_id: event.id.clone(),
+        client_id: event.client_id.clone(),
+        handled: event.handled.clone(),
+        replaces_client_id: event.replaces_client_id.clone(),
+        resulting_client_id: event.resulting_client_id.clone(),
+    }
+}
+
+#[derive(Insertable)]
+#[table_name = "requests"]
+pub struct DBRequest {
+    pub id: Uuid,
+    pub body: Option<String>,
+    pub body_used: bool,
+    pub cache: String,
+    pub credentials: String,
+    pub destination: String,
+    pub headers: serde_json::Value,
+    pub integrity: String,
+    pub method: String,
+    pub mode: String,
+    pub redirect: String,
+    pub referrer: String,
+    pub referrer_policy: String,
+    pub url: String,
+    pub signal: serde_json::Value,
+}
+
+pub fn db_request_from_aggregate(request: &RequestData) -> DBRequest {
+    DBRequest {
+        id: Uuid::new_v4(),
+        body: request.body.clone(),
+        body_used: request.body_used,
+        cache: request.cache.clone(),
+        credentials: request.credentials.clone(),
+        destination: request.destination.clone(),
+        headers: request.headers.clone(),
+        integrity: request.integrity.clone(),
+        method: request.method.clone(),
+        mode: request.mode.clone(),
+        redirect: request.redirect.clone(),
+        referrer: request.referrer.clone(),
+        referrer_policy: request.referrer_policy.clone(),
+        url: request.url.clone(),
+        signal: request.signal.clone(),
+    }
+}
+
+#[derive(Insertable)]
+#[table_name = "responses"]
+pub struct DBResponse {
+    pub id: Uuid,
+    pub body: Option<String>,
+    pub body_used: bool,
+    pub headers: serde_json::Value,
+    pub ok: bool,
+    pub redirected: bool,
+    pub status: i32,
+    pub status_text: String,
+    pub response_type: String,
+    pub url: String,
+}
+
+pub fn db_response_from_aggregate(response: &ResponseData) -> DBResponse {
+    DBResponse {
+        id: Uuid::new_v4(),
+        body: response.body.clone(),
+        body_used: response.body_used,
+        headers: response.headers.clone(),
+        ok: response.ok,
+        redirected: response.redirected,
+        status: response.status as i32,
+        status_text: response.status_text.clone(),
+        response_type: response.response_type.clone(),
+        url: response.url.clone(),
+    }
+}
+
+table! {
+    events (id) {
+        id -> Uuid,
+        browser_id -> Varchar,
+        client_id -> Varchar,
+        handled -> Jsonb,
+        replaces_client_id -> Varchar,
+        resulting_client_id -> Varchar,
+    }
+}
+
+table! {
+    requests (event_id) {
+        id -> Uuid,
+        event_id -> Uuid,
+        body -> Nullable<Text>,
+        body_used -> Bool,
+        cache -> Varchar,
+        credentials -> Varchar,
+        destination -> Varchar,
+        headers -> Jsonb,
+        integrity -> Varchar,
+        method -> Varchar,
+        mode -> Varchar,
+        redirect -> Varchar,
+        referrer -> Varchar,
+        referrer_policy -> Varchar,
+        url -> Varchar,
+        signal -> Jsonb,
+    }
+}
+
+table! {
+    responses (event_id) {
+        id -> Uuid,
+        event_id -> Uuid,
+        body -> Nullable<Text>,
+        body_used -> Bool,
+        headers -> Jsonb,
+        ok -> Bool,
+        redirected -> Bool,
+        status -> Int4,
+        status_text -> Varchar,
+        response_type -> Varchar,
+        url -> Varchar,
+    }
+}
+
+joinable!(requests -> events (event_id));
+joinable!(responses -> events (event_id));
+
+allow_tables_to_appear_in_same_query!(events, requests, responses,);

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,0 +1,75 @@
+// @generated automatically by Diesel CLI.
+
+diesel::table! {
+    events (id) {
+        id -> Int4,
+        #[max_length = 255]
+        browser_id -> Nullable<Varchar>,
+        #[max_length = 255]
+        client_id -> Nullable<Varchar>,
+        handled -> Nullable<Bool>,
+        #[max_length = 255]
+        replaces_client_id -> Nullable<Varchar>,
+        #[max_length = 255]
+        resulting_client_id -> Nullable<Varchar>,
+    }
+}
+
+diesel::table! {
+    requests (id) {
+        id -> Int4,
+        event_id -> Nullable<Int4>,
+        body -> Nullable<Text>,
+        body_used -> Nullable<Bool>,
+        #[max_length = 255]
+        cache -> Nullable<Varchar>,
+        #[max_length = 255]
+        credentials -> Nullable<Varchar>,
+        #[max_length = 255]
+        destination -> Nullable<Varchar>,
+        headers -> Nullable<Jsonb>,
+        #[max_length = 255]
+        integrity -> Nullable<Varchar>,
+        #[max_length = 255]
+        method -> Nullable<Varchar>,
+        #[max_length = 255]
+        mode -> Nullable<Varchar>,
+        #[max_length = 255]
+        redirect -> Nullable<Varchar>,
+        #[max_length = 255]
+        referrer -> Nullable<Varchar>,
+        #[max_length = 255]
+        referrer_policy -> Nullable<Varchar>,
+        #[max_length = 255]
+        url -> Nullable<Varchar>,
+        signal -> Nullable<Text>,
+    }
+}
+
+diesel::table! {
+    responses (id) {
+        id -> Int4,
+        event_id -> Nullable<Int4>,
+        body -> Nullable<Text>,
+        body_used -> Nullable<Bool>,
+        headers -> Nullable<Jsonb>,
+        ok -> Nullable<Bool>,
+        redirected -> Nullable<Bool>,
+        status -> Nullable<Int4>,
+        #[max_length = 255]
+        status_text -> Nullable<Varchar>,
+        #[max_length = 255]
+        response_type -> Nullable<Varchar>,
+        #[max_length = 255]
+        url -> Nullable<Varchar>,
+    }
+}
+
+diesel::joinable!(requests -> events (event_id));
+diesel::joinable!(responses -> events (event_id));
+
+diesel::allow_tables_to_appear_in_same_query!(
+    events,
+    requests,
+    responses,
+);


### PR DESCRIPTION
* Objective

This MR objective is about storing the service worker events coming from the front end in two different databases (for different purposes), Postgres and influxdb.

* Why

We need to start collecting data, and this is the first commit that enables such an operation, we now collect Solana web requests coming from the dApps with this MR:

* How

This commit finalizes the influx repository with all the details and creates the Postgres repository along with its DB models and migrations.